### PR TITLE
fix printing CLI help

### DIFF
--- a/src/main/java/de/xbrowniecodez/jbytemod/Main.java
+++ b/src/main/java/de/xbrowniecodez/jbytemod/Main.java
@@ -24,11 +24,11 @@ public enum Main {
     @SneakyThrows
     private void start(String[] args) {
         CommandLine cmd = parseCommandLine(args);
+        this.logger = new Logging();
+        this.jByteMod = new JByteMod(false);
         if (cmd.hasOption("help")) {
             this.printHelpAndExit();
         }
-        this.logger = new Logging();
-        this.jByteMod = new JByteMod(false);
         this.discord = new Discord("1184572566795468881");
         this.loadFileIfNeeded(cmd, jByteMod);
         SwingUtilities.invokeLater(() -> this.jByteMod.setVisible(true));


### PR DESCRIPTION
Building and executing the latest commit with `--help` throws a NullPointerException because jByteMod is not initialized.

```shell
$ java -jar target/JByteMod-Remastered-2.9.0.jar --help
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "de.xbrowniecodez.jbytemod.JByteMod.getTitle()" because the return value of "de.xbrowniecodez.jbytemod.Main.getJByteMod()" is null
        at de.xbrowniecodez.jbytemod.Main.printHelpAndExit(Main.java:61)
        at de.xbrowniecodez.jbytemod.Main.start(Main.java:28)
        at de.xbrowniecodez.jbytemod.Main.main(Main.java:23)
```